### PR TITLE
add missing <functional> include

### DIFF
--- a/src/commandqueue.h
+++ b/src/commandqueue.h
@@ -6,6 +6,8 @@
 #include <QQueue>
 #include <QMutex>
 
+#include <functional>
+
 #include "commandentity.h"
 
 class CommandReceipt


### PR DESCRIPTION
I am just trying to build recent GhostCloud for Sailfish on OBS (OpenBuildService): https://build.sailfishos.org/package/live_build_log/home:karry/harbour-owncloud/sailfish_latest_aarch64/aarch64